### PR TITLE
fixed bug - font and icon links in html

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>New Tab</title>
 
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Lato:300,700" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css">
 
     <script src="js/app.min.js" defer></script>

--- a/src/index.html
+++ b/src/index.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>New Tab</title>
 
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Lato:300,700" rel="stylesheet">
     <!-- build:css -->
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/styles.css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,700">
     <!-- endbuild -->
 
     <!-- build:js -->


### PR DESCRIPTION
## Purpose
* Fixes a bug in html file. Google fonts and icon links were being edited out by the gulp 'html' task

## Approach/Fixes
* Moved the font and icon links out of the htmlReplace tags

## Testing
* Load devTab as a an unpacked chrome extension
* Confirm that icons are visible and font is Lato
