### PR TITLE
remove proxyURL from CSS validation fetch call

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -313,10 +313,9 @@ CONTROLLER
     $('#check-css').attr('disabled', 'disabled');
 
     const content = encodeURIComponent($('#css-markup textarea').val());
-    const proxyURL = 'https://cors-anywhere.herokuapp.com/';
     const validatorURL = `http://jigsaw.w3.org/css-validator/validator?text=${content}&profile=css3&output=json`;
 
-    fetch(proxyURL + validatorURL)
+    fetch(validatorURL)
       .then((response) => {
         if (!response.ok) {
           cssView.errorOutput();


### PR DESCRIPTION
## Purpose
* Kinda surprised this actually happened, but my [stack overflow question](https://stackoverflow.com/questions/46855633/how-to-make-a-simple-get-request-if-the-resource-doesnt-allow-cors/46860479#46860479) from several months ago actually ended up in a merged pull request with W3C CSS Validator service

## Approach/Fixes
* No longer need the proxy url to make a CORS request for validation service, so i just removed the url variable
