### PR TITLE
Update hoek for security issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 Thumbs.db
 
 node_modules
+
+package-lock.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -962,10 +962,7 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -4829,14 +4826,13 @@
       "requires": {
         "boom": "2.10.1",
         "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
         "sntp": "1.0.9"
       }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
       "dev": true
     },
     "home-or-tmp": {
@@ -8160,10 +8156,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "dev": true
     },
     "socket.io": {
       "version": "1.6.0",


### PR DESCRIPTION
## Purpose
* Github shows sign of security issue vulnerability through outdated hoek dependency

## Approach/Fixes
* Github suggests updating hoek to version 5.0.3
